### PR TITLE
register EthAccount with legacy amino codec in order to use EthAccounts

### DIFF
--- a/encoding/codec/codec.go
+++ b/encoding/codec/codec.go
@@ -14,6 +14,7 @@ import (
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	sdk.RegisterLegacyAminoCodec(cdc)
 	cryptocodec.RegisterCrypto(cdc)
+	ethermint.RegisterLegacyAminoCodec(cdc)
 	codec.RegisterEvidences(cdc)
 }
 

--- a/types/codec.go
+++ b/types/codec.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
@@ -23,4 +24,9 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		(*ExtensionOptionsWeb3TxI)(nil),
 		&ExtensionOptionsWeb3Tx{},
 	)
+}
+
+// RegisterLegacyAminoCodec registers the tendermint concrete client-related implmentations and interfaces
+func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&EthAccount{}, "ethermint/EthAccount", nil)
 }


### PR DESCRIPTION
Registers the EthAccount with the legacy amino codec in order to allow usage over tendermint RPC