### PR TITLE
Use an indepent parameter subspace in migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -418,7 +418,7 @@ func NewEthermintApp(
 	// Set authority to x/gov module account to only expect the module account to update params
 	evmSs := app.GetSubspace(evmtypes.ModuleName)
 	app.EvmKeeper = evmkeeper.NewKeeper(
-		appCodec, keys[evmtypes.StoreKey], tkeys[evmtypes.TransientKey], authtypes.NewModuleAddress(govtypes.ModuleName),
+		appCodec, cdc, keys[evmtypes.StoreKey], tkeys[evmtypes.TransientKey], authtypes.NewModuleAddress(govtypes.ModuleName),
 		app.AccountKeeper, app.BankKeeper, app.StakingKeeper, app.FeeMarketKeeper,
 		nil, geth.NewEVM, tracer, evmSs,
 	)
@@ -507,7 +507,7 @@ func NewEthermintApp(
 		transferModule,
 		// Ethermint app modules
 		feemarket.NewAppModule(app.FeeMarketKeeper, feeMarketSs),
-		evm.NewAppModule(app.EvmKeeper, app.AccountKeeper, evmSs),
+		evm.NewAppModule(app.EvmKeeper, app.AccountKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -41,6 +41,8 @@ import (
 type Keeper struct {
 	// Protobuf codec
 	cdc codec.BinaryCodec
+	// Amino Codec used for legacy parameters
+	legacyAmino *codec.LegacyAmino
 	// Store key required for the EVM Prefix KVStore. It is required by:
 	// - storing account's Storage State
 	// - storing account's Code
@@ -83,6 +85,7 @@ type Keeper struct {
 // NewKeeper generates new evm module keeper
 func NewKeeper(
 	cdc codec.BinaryCodec,
+	legacyAmino *codec.LegacyAmino,
 	storeKey, transientKey storetypes.StoreKey,
 	authority sdk.AccAddress,
 	ak types.AccountKeeper,
@@ -107,6 +110,7 @@ func NewKeeper(
 	// NOTE: we pass in the parameter space to the CommitStateDB in order to use custom denominations for the EVM operations
 	return &Keeper{
 		cdc:               cdc,
+		legacyAmino:       legacyAmino,
 		authority:         authority,
 		accountKeeper:     ak,
 		bankKeeper:        bankKeeper,

--- a/x/evm/keeper/migrations.go
+++ b/x/evm/keeper/migrations.go
@@ -28,10 +28,9 @@ type Migrator struct {
 }
 
 // NewMigrator returns a new Migrator.
-func NewMigrator(keeper Keeper, legacySubspace types.Subspace) Migrator {
+func NewMigrator(keeper Keeper) Migrator {
 	return Migrator{
-		keeper:         keeper,
-		legacySubspace: legacySubspace,
+		keeper: keeper,
 	}
 }
 
@@ -39,8 +38,9 @@ func NewMigrator(keeper Keeper, legacySubspace types.Subspace) Migrator {
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	return v3.MigrateStore(
 		ctx,
-		m.legacySubspace,
-		m.keeper.storeKey,
 		m.keeper.cdc,
+		m.keeper.legacyAmino,
+		m.keeper.storeKey,
+		m.keeper.transientKey,
 	)
 }

--- a/x/evm/keeper/migrations.go
+++ b/x/evm/keeper/migrations.go
@@ -18,13 +18,11 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v3 "github.com/evmos/ethermint/x/evm/migrations/v3"
-	"github.com/evmos/ethermint/x/evm/types"
 )
 
 // Migrator is a struct for handling in-place store migrations.
 type Migrator struct {
-	keeper         Keeper
-	legacySubspace types.Subspace
+	keeper Keeper
 }
 
 // NewMigrator returns a new Migrator.

--- a/x/evm/migrations/v3/store_test.go
+++ b/x/evm/migrations/v3/store_test.go
@@ -38,9 +38,10 @@ func TestMigrate(t *testing.T) {
 
 	err := v3.MigrateStore(
 		ctx,
-		paramstore,
-		storeKey,
 		cdc,
+		encCfg.Amino,
+		storeKey,
+		tKey,
 	)
 	require.NoError(t, err)
 
@@ -143,9 +144,10 @@ func TestMigrate_Mainnet(t *testing.T) {
 
 	err := v3.MigrateStore(
 		ctx,
-		paramstore,
-		storeKey,
 		cdc,
+		encCfg.Amino,
+		storeKey,
+		tKey,
 	)
 	require.NoError(t, err)
 

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -119,12 +119,11 @@ type AppModule struct {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(k *keeper.Keeper, ak types.AccountKeeper, ss types.Subspace) AppModule {
+func NewAppModule(k *keeper.Keeper, ak types.AccountKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         k,
 		ak:             ak,
-		legacySubspace: ss,
 	}
 }
 
@@ -144,7 +143,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), am.keeper)
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
-	m := keeper.NewMigrator(*am.keeper, am.legacySubspace)
+	m := keeper.NewMigrator(*am.keeper)
 
 	// This migration is a Kava specific migration that also includes the
 	// upstream migrations from 3 to 5.


### PR DESCRIPTION
This fixes the consensus error on public testnet and aligns behavior with +2/3 of the voting power during new blocks and during replay of old blocks.