### PR TITLE
Initialize precompiles in InitGenesis

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -426,7 +426,7 @@ func NewEthermintApp(
 		appCodec, keys[evmtypes.StoreKey], tkeys[evmtypes.TransientKey],
 		authtypes.NewModuleAddress(govtypes.ModuleName),
 		app.AccountKeeper, app.BankKeeper, stakingKeeper, app.FeeMarketKeeper,
-		vm.NewEVM, tracer, evmSs,
+		vm.NewEVMWithEnabledPrecompiles, tracer, evmSs,
 	)
 
 	// Create IBC Keeper

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/holiman/uint256 v1.2.1
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
@@ -142,6 +141,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.1.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.2.1 // indirect
 	github.com/huandu/skiplist v1.2.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -223,7 +223,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	// Use cosmos-sdk fork with staking transfer events, and custom tally handler support
 	github.com/cosmos/cosmos-sdk => github.com/kava-labs/cosmos-sdk v0.47.10-kava.2
-	github.com/ethereum/go-ethereum => github.com/Kava-Labs/go-ethereum v1.10.27-0.20240308170502-da7973e5eee0
+	github.com/ethereum/go-ethereum => github.com/Kava-Labs/go-ethereum v1.10.27-0.20240513233504-6e038346780b
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Kava-Labs/go-ethereum v1.10.27-0.20240308170502-da7973e5eee0 h1:pPFzOjEZmihLk70TQRPUCWs8uar6nfh4vZ/I1r0zeso=
-github.com/Kava-Labs/go-ethereum v1.10.27-0.20240308170502-da7973e5eee0/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
+github.com/Kava-Labs/go-ethereum v1.10.27-0.20240513233504-6e038346780b h1:gTLS1VJL+6TEcttEmQ9rAmm/UZZw23WlQf6n8R/Xjx0=
+github.com/Kava-Labs/go-ethereum v1.10.27-0.20240513233504-6e038346780b/go.mod h1:tvRm5KYJQ6LT+uss34spIP1oi6JgCfsFYiMKwJLZr6M=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -27,8 +27,13 @@ import (
 	precompile_modules "github.com/ethereum/go-ethereum/precompile/modules"
 	ethermint "github.com/evmos/ethermint/types"
 	"github.com/evmos/ethermint/x/evm/keeper"
+	"github.com/evmos/ethermint/x/evm/statedb"
 	"github.com/evmos/ethermint/x/evm/types"
 )
+
+const PrecompileNonce uint64 = 1
+
+var PrecompileCode = []byte{0x1}
 
 // InitGenesis initializes genesis state based on exported genesis
 func InitGenesis(
@@ -51,6 +56,25 @@ func InitGenesis(
 	err = k.SetParams(ctx, data.Params)
 	if err != nil {
 		panic(fmt.Errorf("error setting params %s", err))
+	}
+
+	txConfig := statedb.NewEmptyTxConfig(common.BytesToHash(ctx.HeaderHash().Bytes()))
+	stateDB := statedb.New(ctx, k, txConfig)
+
+	for _, hexAddr := range data.Params.EnabledPrecompiles {
+		addr := common.HexToAddress(hexAddr)
+
+		// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
+		// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
+		stateDB.SetNonce(addr, PrecompileNonce)
+		// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
+		// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
+		// that it does not attempt to invoke a non-existent contract.
+		stateDB.SetCode(addr, PrecompileCode)
+	}
+
+	if err := stateDB.Commit(); err != nil {
+		panic(err)
 	}
 
 	// ensure evm module account is set

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -68,7 +68,14 @@ func (k *Keeper) NewEVM(
 		tracer = k.Tracer(ctx, msg, cfg.ChainConfig)
 	}
 	vmConfig := k.VMConfig(ctx, msg, cfg, tracer)
-	return k.evmConstructor(blockCtx, txCtx, stateDB, cfg.ChainConfig, vmConfig)
+
+	enabledPrecompiles := k.GetParams(ctx).EnabledPrecompiles
+	enabledPrecompileAddrs := make([]common.Address, len(enabledPrecompiles))
+	for i, p := range enabledPrecompiles {
+		enabledPrecompileAddrs[i] = common.HexToAddress(p)
+	}
+
+	return k.evmConstructor(blockCtx, txCtx, stateDB, cfg.ChainConfig, vmConfig, enabledPrecompileAddrs)
 }
 
 // GetHashFn implements vm.GetHashFunc for Ethermint. It handles 3 cases:

--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -22,6 +22,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -93,4 +94,5 @@ type Constructor func(
 	stateDB vm.StateDB,
 	chainConfig *params.ChainConfig,
 	config vm.Config,
+	enabledPrecompiles []common.Address,
 ) *vm.EVM


### PR DESCRIPTION
Moved to https://github.com/Kava-Labs/ethermint/pull/58

PR is deprecated, `Initialize precompiles in InitGenesis` should follow these guildelines: https://kava-labs.atlassian.net/wiki/spaces/ENG/pages/1469448211/Module+Genesis+Guidelines

PR breaks this requirement: `ExportGenesis(InitGenesis(genesisState)) == genesisState`, because we call `SetNonce` & `SetCode` in InitGenesis which creates evm accounts, then these accounts will be exported in `ExportGenesis`.

We should instead rely on GenesisAccount{ 0x100…0, 0x01, []State{}) being in the genesis state for each enabled precompile

