### PR TITLE
refactor: Flatten & remove unused BankKeeper interface methods

### DIFF
--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -45,8 +45,8 @@ type AccountKeeper interface {
 
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
-	authtypes.BankKeeper
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error


### PR DESCRIPTION
`authtypes.BankKeeper` contains:
- `IsSendEnabledCoins`
- `SendCoins`
- `SendCoinsFromAccountToModule`

`x/evm` only requires `SendCoinsFromAccountToModule`. This removes the inclusion of `authtypes.BankKeeper` and the unused methods so implementations of `BankKeeper` do not need to implement the unused methods.