### PR TITLE
feat: Use SpendableCoin instead of full balance when querying gas token

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -326,7 +326,11 @@ func (k *Keeper) GetBalance(ctx sdk.Context, addr common.Address) *big.Int {
 	if evmDenom == "" {
 		return big.NewInt(-1)
 	}
-	coin := k.bankKeeper.GetBalance(ctx, cosmosAddr, evmDenom)
+
+	// Only spendable coin is considered as balance from EVM perspective.
+	// Locked coins are not shown in the balance to prevent misleading
+	// insufficient balance errors for users.
+	coin := k.bankKeeper.SpendableCoin(ctx, cosmosAddr, evmDenom)
 	return coin.Amount.BigInt()
 }
 

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -90,7 +90,11 @@ func (k *Keeper) SetBalance(ctx sdk.Context, addr common.Address, amount *big.In
 	cosmosAddr := sdk.AccAddress(addr.Bytes())
 
 	params := k.GetParams(ctx)
-	coin := k.bankKeeper.GetBalance(ctx, cosmosAddr, params.EvmDenom)
+
+	// Since spendable balances are fetched to get balances, when setting balances
+	// it should also compare with spendable coins as well to get the correct
+	// delta.
+	coin := k.bankKeeper.SpendableCoin(ctx, cosmosAddr, params.EvmDenom)
 	balance := coin.Amount.BigInt()
 	delta := new(big.Int).Sub(amount, balance)
 	switch delta.Sign() {

--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -46,7 +46,7 @@ type AccountKeeper interface {
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
 	authtypes.BankKeeper
-	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SpendableCoin(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error


### PR DESCRIPTION
Related PR: https://github.com/Kava-Labs/kava/pull/1957

Use SpendableCoin instead of full balance prevents insufficient balance errors when vesting accounts attempt to spend their locked coins.

Also used when setting balances in order to have the correct balance delta.