### PR TITLE
Add basic enabled genesis precompile checks

### DIFF
--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -90,7 +90,6 @@ func InitGenesis(
 		for _, storage := range account.Storage {
 			k.SetState(ctx, address, common.HexToHash(storage.Key), common.HexToHash(storage.Value).Bytes())
 		}
-
 	}
 
 	for _, precompileAddr := range data.Params.GetEnabledPrecompiles() {


### PR DESCRIPTION
Adds genesis validations for ensuring that enabled precompiles have EthAcct's, Code Set, and a nonce set.