### PR TITLE
fix!: Remove unused fields verifyingContract & salt from EIP712 domain separator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,13 @@ on:
   push:
     branches:
       - main
+permissions:
+  # Required: allow read access to the content for analysis.
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
 jobs:
   golangci:
     name: Run golangci-lint
@@ -19,7 +26,6 @@ jobs:
           go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
             **/**.go
@@ -27,8 +33,10 @@ jobs:
             go.sum
       - uses: golangci/golangci-lint-action@v3.3.1
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          # Required: the version of golangci-lint is required and must be
+          # specified without patch version: Newer versions are currently not
+          # passing.
+          version: v1.59
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         # Check only if there are differences in the source code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,6 @@ on:
   push:
     branches:
       - main
-permissions:
-  # Required: allow read access to the content for analysis.
-  contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  pull-requests: read
-  # Optional: allow write access to checks to allow the action to annotate code in the PR.
-  checks: write
 jobs:
   golangci:
     name: Run golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
           go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
             **/**.go

--- a/ethereum/eip712/msg_test.go
+++ b/ethereum/eip712/msg_test.go
@@ -79,9 +79,7 @@ func TestExtractMsgTypes(t *testing.T) {
 				"EIP712Domain": [
 					{ "name": "name", "type": "string" },
 					{ "name": "version", "type": "string" },
-					{ "name": "chainId", "type": "uint256" },
-					{ "name": "verifyingContract", "type": "string" },
-					{ "name": "salt", "type": "string" }
+					{ "name": "chainId", "type": "uint256" }
 				],
 				"Fee": [
 					{ "name": "amount", "type": "Coin[]" },

--- a/ethereum/eip712/types.go
+++ b/ethereum/eip712/types.go
@@ -7,11 +7,25 @@ import (
 
 func getTypedDataDomain(chainID uint64) apitypes.TypedDataDomain {
 	return apitypes.TypedDataDomain{
-		Name:              "Kava Cosmos",
-		Version:           "1.0.0",
-		ChainId:           math.NewHexOrDecimal256(int64(chainID)),
-		VerifyingContract: "kavaCosmos",
-		Salt:              "0",
+		Name:    "Kava Cosmos",
+		Version: "1.0.0",
+		ChainId: math.NewHexOrDecimal256(int64(chainID)),
+
+		// Fields below are not used signature verification so they are
+		// explicitly set empty to exclude them from the hash to be signed.
+
+		// Salt in most cases is not used, other chains sometimes set the
+		// chainID as the salt instead of using the chainId field and not
+		// together.
+		// Discussion on salt usage:
+		// https://github.com/OpenZeppelin/openzeppelin-contracts/issues/4318
+		Salt: "",
+
+		// VerifyingContract is empty as there is no contract that is verifying
+		// the signature. Signature verification is done in the ante handler.
+		// Smart contracts that handle EIP712 signatures will include their own
+		// address in the domain separator.
+		VerifyingContract: "",
 	}
 }
 
@@ -32,7 +46,7 @@ func getRootTypes() apitypes.Types {
 			},
 			{
 				Name: "verifyingContract",
-				Type: "string",
+				Type: "address",
 			},
 			{
 				Name: "salt",

--- a/ethereum/eip712/types.go
+++ b/ethereum/eip712/types.go
@@ -44,14 +44,6 @@ func getRootTypes() apitypes.Types {
 				Name: "chainId",
 				Type: "uint256",
 			},
-			{
-				Name: "verifyingContract",
-				Type: "address",
-			},
-			{
-				Name: "salt",
-				Type: "string",
-			},
 		},
 		"Tx": {
 			{Name: "account_number", Type: "string"},

--- a/ethereum/eip712/types_test.go
+++ b/ethereum/eip712/types_test.go
@@ -1,0 +1,27 @@
+package eip712
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedDataDomain(t *testing.T) {
+	domain := getTypedDataDomain(1234)
+
+	domainMap := domain.Map()
+
+	// Verify both len and expected contents in order to assert that no other
+	// fields are present
+	require.Len(t, domainMap, 3)
+	require.Contains(t, domainMap, "chainId")
+	require.Contains(t, domainMap, "name")
+	require.Contains(t, domainMap, "version")
+
+	// Extra check to ensure that the fields that are not used for signature
+	// verification are not present in the map. Should be in conjunction with
+	// the checks above to ensure there isn't a different variant of these
+	// fields present, e.g. different casing.
+	require.NotContains(t, domainMap, "verifyingContract")
+	require.NotContains(t, domainMap, "salt")
+}


### PR DESCRIPTION
This is a breaking change as it changes the expected fields in the EIP712 data that is signed.

- Set `verifyingContract` field to empty string to exclude it
- `Salt` is also set to empty as it is unused
- Remove the types for `verifyingContract` and `Salt` as it is unused now the fields are omitted.

To be backported to `kava/release/v0.27.x` release branch